### PR TITLE
Fixed Decoder for empty arrays

### DIFF
--- a/src/TNetstring/Decoder.php
+++ b/src/TNetstring/Decoder.php
@@ -42,7 +42,7 @@ class TNetstring_Decoder
             $values[]    = $this->convertPayloadToPHPValue($payload, $payloadType);
         }
         
-        return count($values) > 1 ? $values : $values[0];
+        return count($values) !== 1 ? $values : $values[0];
     }
 
     protected function convertPayloadToPHPValue($payload, $type) {


### PR DESCRIPTION
The code threw a notice if the array stayed empty in the while loop. Not
sure if returning the empty array is the intended behaviour, though.
